### PR TITLE
Remove "Update URI" from plugin headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,21 @@ This plugin adds a section called "Block X-ray" to the Document sidebar in the e
 
 Development of this code happens at [github.com/salcode/block-xray-attributes](https://github.com/salcode/block-xray-attributes)
 
+### Why Don't I See an Update from 1.1.0
+
+When the initial version (`1.1.0`) was uploaded to the WordPress.org plugin repository, the [Update URI plugin header](https://make.wordpress.org/core/2021/06/29/introducing-update-uri-plugin-header-in-wordpress-5-8/) was accidentally included. This plugin header prevents downloading updates from the WordPress.org API.
+
+The `Update URI` header is very useful when your plugin is NOT hosted on the WordPress.org repository. However, now that the plugin is hosted on the WordPress.org repository, the `Update URI` plugin header should not be included.
+
+If you are stuck on version `1.1.0` and want the latest version, you should `Delete` this plugin and reinstall it.
+
+Once you move beyond version `1.1.0`, you should no longer experience this problem.
+
 ## Changelog
+
+### Unreleased
+
+* Remove "Update URI" from plugin headers
 
 ### 1.1.0
 

--- a/block-xray-attributes.php
+++ b/block-xray-attributes.php
@@ -10,7 +10,6 @@
  * Author URI:        https://salferrarello.com/
  * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Update URI:        https://github.com/salcode/block-xray-attributes
  * Text Domain:       block-xray-attributes
  * Domain Path:       /languages
  */


### PR DESCRIPTION
The presence of the "Update URI" header in the main plugin file prevents
updating the plugin from the wordpress.org plugin repository.

We are removing this line so the updates work properly.

Resolves #18