### PR TITLE
Add copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Once you move beyond version `1.1.0`, you should no longer experience this probl
 
 ## Changelog
 
+### Unreleased
+
+* Add `Copy Block Data` button ([#17 Add button to copy data](https://github.com/salcode/block-xray-attributes/issues/17))
+
 ### 1.1.1
 
 * Remove "Update URI" from plugin headers

--- a/src/components/CopyButton/index.js
+++ b/src/components/CopyButton/index.js
@@ -1,12 +1,16 @@
 import PropTypes from 'prop-types';
 
+import { useCopyToClipboard } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 export default function CopyButton({
   content,
 }) {
+  const ref = useCopyToClipboard(content);
   return (
-    <button>
+    <button
+      ref={ref}
+    >
       {__( 'Copy Block Data', 'block-xray-attributes' )}
     </button>
   );

--- a/src/components/CopyButton/index.js
+++ b/src/components/CopyButton/index.js
@@ -1,0 +1,7 @@
+export default function CopyButton() {
+  return (
+    <button>
+      Copy Block Data
+    </button>
+  );
+}

--- a/src/components/CopyButton/index.js
+++ b/src/components/CopyButton/index.js
@@ -1,9 +1,17 @@
+import PropTypes from 'prop-types';
+
 import { __ } from '@wordpress/i18n';
 
-export default function CopyButton() {
+export default function CopyButton({
+  content,
+}) {
   return (
     <button>
       {__( 'Copy Block Data', 'block-xray-attributes' )}
     </button>
   );
 }
+
+CopyButton.propTypes = {
+  content: PropTypes.string.isRequired,
+};

--- a/src/components/CopyButton/index.js
+++ b/src/components/CopyButton/index.js
@@ -1,7 +1,9 @@
+import { __ } from '@wordpress/i18n';
+
 export default function CopyButton() {
   return (
     <button>
-      Copy Block Data
+      {__( 'Copy Block Data', 'block-xray-attributes' )}
     </button>
   );
 }

--- a/src/components/JavaScriptObject/index.js
+++ b/src/components/JavaScriptObject/index.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 
+import CopyButton from '../CopyButton';
+
 const pretty = (object) => {
   return JSON.stringify(object, null, 2);
 };
@@ -17,6 +19,7 @@ export default function JavaScriptObject({ object }) {
           {pretty(object)}
         </code>
       </pre>
+      <CopyButton />
     </>
   );
 }

--- a/src/components/JavaScriptObject/index.js
+++ b/src/components/JavaScriptObject/index.js
@@ -11,11 +11,13 @@ const codeStyles = {
 
 export default function JavaScriptObject({ object }) {
   return (
-    <pre>
-      <code style={codeStyles}>
-        {pretty(object)}
-      </code>
-    </pre>
+    <>
+      <pre>
+        <code style={codeStyles}>
+          {pretty(object)}
+        </code>
+      </pre>
+    </>
   );
 }
 

--- a/src/components/JavaScriptObject/index.js
+++ b/src/components/JavaScriptObject/index.js
@@ -20,7 +20,9 @@ export default function JavaScriptObject({ object }) {
           {prettyCode}
         </code>
       </pre>
-      <CopyButton />
+      <CopyButton
+        content={prettyCode}
+      />
     </>
   );
 }

--- a/src/components/JavaScriptObject/index.js
+++ b/src/components/JavaScriptObject/index.js
@@ -12,11 +12,12 @@ const codeStyles = {
 };
 
 export default function JavaScriptObject({ object }) {
+  const prettyCode = pretty(object);
   return (
     <>
       <pre>
         <code style={codeStyles}>
-          {pretty(object)}
+          {prettyCode}
         </code>
       </pre>
       <CopyButton />


### PR DESCRIPTION
Note: This PR breaks with older versions of WordPress (e.g. WP `5.5`).

See #17 

![image](https://user-images.githubusercontent.com/5194588/155798031-8c8f776a-803b-4c95-b522-78c7ee85213e.png)
